### PR TITLE
Correct ID variable - tokenId should be itemId

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -28,7 +28,7 @@ export default function Home() {
       let price = ethers.utils.formatUnits(i.price.toString(), 'ether')
       let item = {
         price,
-        tokenId: i.tokenId.toNumber(),
+        itemId: i.itemId.toNumber(),
         seller: i.seller,
         owner: i.owner,
         image: meta.data.image,
@@ -48,7 +48,7 @@ export default function Home() {
     const contract = new ethers.Contract(nftmarketaddress, Market.abi, signer)
 
     const price = ethers.utils.parseUnits(nft.price.toString(), 'ether')
-    const transaction = await contract.createMarketSale(nftaddress, nft.tokenId, {
+    const transaction = await contract.createMarketSale(nftaddress, nft.itemId, {
       value: price
     })
     await transaction.wait()


### PR DESCRIPTION
NFTs objects should have itemId propriety and not tokenId propriety.
Creating a token but not listing it will defer the itemId and tokenId, fetching the marketplace based on tokenId will result in the wrong token being fetched.

For example, you might have created 18 tokens (tokenId.last = 18), but listed only 5. The 4th tokenId will not correspond to the 4th itemId.