### PR TITLE
Replace <img> with <image> tags / Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,7 @@ node_modules
 #Hardhat files
 cache
 artifacts
+
+# OS specific local files
+.DS_Store
+Thumbs.db

--- a/pages/create-nft.js
+++ b/pages/create-nft.js
@@ -3,6 +3,7 @@ import { ethers } from 'ethers'
 import { create as ipfsHttpClient } from 'ipfs-http-client'
 import { useRouter } from 'next/router'
 import Web3Modal from 'web3modal'
+import Image from 'next/image'
 
 const client = ipfsHttpClient('https://ipfs.infura.io:5001/api/v0')
 
@@ -93,7 +94,7 @@ export default function CreateItem() {
         />
         {
           fileUrl && (
-            <img className="rounded mt-4" width="350" src={fileUrl} />
+            <image className="rounded mt-4" width="350" src={fileUrl} />
           )
         }
         <button onClick={listNFTForSale} className="font-bold mt-4 bg-pink-500 text-white rounded p-4 shadow-lg">

--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -2,6 +2,7 @@ import { ethers } from 'ethers'
 import { useEffect, useState } from 'react'
 import axios from 'axios'
 import Web3Modal from 'web3modal'
+import Image from 'next/image'
 
 import {
   marketplaceAddress
@@ -53,7 +54,7 @@ export default function CreatorDashboard() {
           {
             nfts.map((nft, i) => (
               <div key={i} className="border shadow rounded-xl overflow-hidden">
-                <img src={nft.image} className="rounded" />
+                <image src={nft.image} className="rounded" />
                 <div className="p-4 bg-black">
                   <p className="text-2xl font-bold text-white">Price - {nft.price} Eth</p>
                 </div>

--- a/pages/index.js
+++ b/pages/index.js
@@ -2,6 +2,7 @@ import { ethers } from 'ethers'
 import { useEffect, useState } from 'react'
 import axios from 'axios'
 import Web3Modal from 'web3modal'
+import Image from 'next/image'
 
 import {
   marketplaceAddress
@@ -67,7 +68,7 @@ export default function Home() {
           {
             nfts.map((nft, i) => (
               <div key={i} className="border shadow rounded-xl overflow-hidden">
-                <img src={nft.image} />
+                <image src={nft.image} />
                 <div className="p-4">
                   <p style={{ height: '64px' }} className="text-2xl font-semibold">{nft.name}</p>
                   <div style={{ height: '70px', overflow: 'hidden' }}>

--- a/pages/my-nfts.js
+++ b/pages/my-nfts.js
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react'
 import axios from 'axios'
 import Web3Modal from 'web3modal'
 import { useRouter } from 'next/router'
+import Image from 'next/image'
 
 import {
   marketplaceAddress
@@ -58,7 +59,7 @@ export default function MyAssets() {
           {
             nfts.map((nft, i) => (
               <div key={i} className="border shadow rounded-xl overflow-hidden">
-                <img src={nft.image} className="rounded" />
+                <image src={nft.image} className="rounded" />
                 <div className="p-4 bg-black">
                   <p className="text-2xl font-bold text-white">Price - {nft.price} Eth</p>
                   <button className="mt-4 w-full bg-pink-500 text-white font-bold py-2 px-12 rounded" onClick={() => listNFT(nft)}>List</button>

--- a/pages/resell-nft.js
+++ b/pages/resell-nft.js
@@ -3,6 +3,7 @@ import { ethers } from 'ethers'
 import { useRouter } from 'next/router'
 import axios from 'axios'
 import Web3Modal from 'web3modal'
+import Image from 'next/image'
 
 import {
   marketplaceAddress
@@ -54,7 +55,7 @@ export default function ResellNFT() {
         />
         {
           image && (
-            <img className="rounded mt-4" width="350" src={image} />
+            <image className="rounded mt-4" width="350" src={image} />
           )
         }
         <button onClick={listNFTForSale} className="font-bold mt-4 bg-pink-500 text-white rounded p-4 shadow-lg">


### PR DESCRIPTION
1. Yarn throws errors on build locally that the img tags in /pages/*.js files have to be replaced with image tags. This update fixes those errors. Yet this was no issue when running the repo in GitPod. Reference link: https://nextjs.org/docs/messages/no-img-element
2. Adding OS specific local files that should not be included in a git repository -> .DS_Store (macOS) and Thumbs.db (Windows)